### PR TITLE
[QATM-405] Fixed inability to connect more than once to LDAP

### DIFF
--- a/src/main/java/com/stratio/qa/utils/LdapUtils.java
+++ b/src/main/java/com/stratio/qa/utils/LdapUtils.java
@@ -29,7 +29,7 @@ public class LdapUtils {
 
     private ConnectionFactory connFactory;
 
-    private ConnectionConfig config = new ConnectionConfig();
+    private ConnectionConfig config;
 
     private BlockingConnectionPool pool;
 
@@ -49,6 +49,7 @@ public class LdapUtils {
     }
 
     public void connect() {
+        this.config = new ConnectionConfig();
         this.config.setLdapUrl(this.url);
         this.config.setUseSSL(this.ssl);
         this.config.setConnectionInitializer(new BindConnectionInitializer(user, new Credential(password)));

--- a/src/test/resources/features/ldapSteps.feature
+++ b/src/test/resources/features/ldapSteps.feature
@@ -8,3 +8,7 @@ Feature: LDAP steps test
     Then the LDAP entry contains the attribute 'uid' with the value 'abrookes'
     And the LDAP entry contains the attribute 'sn' with the value 'Anthony'
     And the LDAP entry contains the attribute 'gidNumber' with the value '101'
+
+  Scenario: Test if multiple scenarios can be run sequentially
+    When I search in LDAP using the filter 'uid=abrookes' and the baseDn 'dc=stratio,dc=com'
+    Then the LDAP entry contains the attribute 'uid' with the value 'abrookes'


### PR DESCRIPTION
Due to a programming error, the LdapUtils class tried to reuse and overwrite its connection config, which after having connected to an LDAP server had been marked as immutable. This caused an unexpected exception.
This behaviour has been corrected (a new ConnectionConfig will be created each time the connect step is invoked) and a test has been added so that it can be detected in the future
