### PR TITLE
[QATM-419] Search for multivalued attributes in LDAP

### DIFF
--- a/src/main/java/com/stratio/qa/specs/ThenGSpec.java
+++ b/src/main/java/com/stratio/qa/specs/ThenGSpec.java
@@ -814,7 +814,7 @@ public class ThenGSpec extends BaseGSpec {
     @Then("^the LDAP entry contains the attribute '(.+?)' with the value '(.+?)'$")
     public void ldapEntryContains(String attributeName, String expectedValue) {
         if (this.commonspec.getPreviousLdapResults().isPresent()) {
-            Assertions.assertThat(this.commonspec.getPreviousLdapResults().get().getEntry().getAttribute(attributeName).getStringValue()).isEqualTo(expectedValue);
+            Assertions.assertThat(this.commonspec.getPreviousLdapResults().get().getEntry().getAttribute(attributeName).getStringValues()).contains(expectedValue);
         } else {
             fail("No previous LDAP results were stored in memory");
         }

--- a/src/test/resources/features/ldapSteps.feature
+++ b/src/test/resources/features/ldapSteps.feature
@@ -12,3 +12,8 @@ Feature: LDAP steps test
   Scenario: Test if multiple scenarios can be run sequentially
     When I search in LDAP using the filter 'uid=abrookes' and the baseDn 'dc=stratio,dc=com'
     Then the LDAP entry contains the attribute 'uid' with the value 'abrookes'
+
+  Scenario: Test if an attribute which has more than one value is correctly found
+    When I search in LDAP using the filter 'cn=Developers' and the baseDn 'dc=stratio,dc=com'
+    Then the LDAP entry contains the attribute 'memberUid' with the value 'uid=adoucet,ou=People,dc=stratio,dc=com'
+    And the LDAP entry contains the attribute 'memberUid' with the value 'uid=irossi,ou=People,dc=stratio,dc=com'


### PR DESCRIPTION
The
@Then("^the LDAP entry contains the attribute '(.?)' with the value '(.?)'$")
step had been implemented with an assertThat().isEqualTo
This presumed the attribute was unique in a LDAP entry. However, many LDAP attributes can be present more than once (such as memberOf, once per each group the user is a member of).
Changing the implementation to return a list of Attributes instead of one and then asserting if the list contains a given attribute will produce the same result as before if the attribute is single-valued, and multivalued attributes will now be correctly processed

Sorry for the missing functionality. I should have thought of this before the initial PR :(
