### PR TITLE
[QATM-809] Configurable port for SSH connection

### DIFF
--- a/src/main/java/com/stratio/qa/specs/GivenGSpec.java
+++ b/src/main/java/com/stratio/qa/specs/GivenGSpec.java
@@ -522,20 +522,20 @@ public class GivenGSpec extends BaseGSpec {
      * @throws Exception exception
      *
      */
-    @Given("^I open a ssh connection to '(.+?)' with user '(.+?)'( and password '(.+?)')?( using pem file '(.+?)')?$")
-    public void openSSHConnection(String remoteHost, String user, String foo, String password, String bar, String pemFile) throws Exception {
+    @Given("^I open a ssh connection to '(.+?)'( in port '(.+?)')? with user '(.+?)'( and password '(.+?)')?( using pem file '(.+?)')?$")
+    public void openSSHConnection(String remoteHost, String tmp, String remotePort, String user, String foo, String password, String bar, String pemFile) throws Exception {
         if ((pemFile == null) || (pemFile.equals("none"))) {
             if (password == null) {
                 throw new Exception("You have to provide a password or a pem file to be used for connection");
             }
-            commonspec.setRemoteSSHConnection(new RemoteSSHConnection(user, password, remoteHost, null));
+            commonspec.setRemoteSSHConnection(new RemoteSSHConnection(user, password, remoteHost, remotePort, null));
             commonspec.getLogger().debug("Opening ssh connection with password: { " + password + "}", commonspec.getRemoteSSHConnection());
         } else {
             File pem = new File(pemFile);
             if (!pem.exists()) {
                 throw new Exception("Pem file: " + pemFile + " does not exist");
             }
-            commonspec.setRemoteSSHConnection(new RemoteSSHConnection(user, null, remoteHost, pemFile));
+            commonspec.setRemoteSSHConnection(new RemoteSSHConnection(user, null, remoteHost, remotePort, pemFile));
             commonspec.getLogger().debug("Opening ssh connection with pemFile: {}", commonspec.getRemoteSSHConnection());
         }
     }

--- a/src/main/java/com/stratio/qa/utils/RemoteSSHConnection.java
+++ b/src/main/java/com/stratio/qa/utils/RemoteSSHConnection.java
@@ -39,6 +39,10 @@ public class RemoteSSHConnection {
      * Default constructor.
      */
     public RemoteSSHConnection(String user, String password, String remoteHost, String pemFile) throws Exception {
+        this(user, password, remoteHost, null, pemFile);
+    }
+
+    public RemoteSSHConnection(String user, String password, String remoteHost, String remotePort, String pemFile) throws Exception {
         // Create session
         JSch jsch = new JSch();
 
@@ -47,7 +51,13 @@ public class RemoteSSHConnection {
             jsch.addIdentity(pemFile);
         }
 
-        Session session = jsch.getSession(user, remoteHost, 22);
+        int sshPort = 22;
+        if (remotePort != null) {
+            // Set remote port if provided
+            sshPort = Integer.parseInt(remotePort);
+        }
+
+        Session session = jsch.getSession(user, remoteHost, sshPort);
 
         // Pass user
         UserInfo ui = new MyUserInfo();


### PR DESCRIPTION
For Mac Users, it's not possible to establish a ssh connection with dcos-cli docker using docker IP and port 22. Therefore, acceptance tests cannot be executed locally.

This PR adds the remote port parameter to the SSH Connection.

More info here: https://stackoverflow.com/questions/37965790/how-do-i-ssh-to-a-docker-in-mac-container