### PR TITLE
[QATM-940] Control adjustLastCapture in Selenium snapshot

### DIFF
--- a/src/main/java/com/stratio/qa/specs/CommonG.java
+++ b/src/main/java/com/stratio/qa/specs/CommonG.java
@@ -504,10 +504,12 @@ public class CommonG {
         File temp = null;
         try {
             oldTrailingImage = ImageIO.read(trailingImage);
-            BufferedImage newTrailingImage = new BufferedImage(
-                    oldTrailingImage.getWidth(), oldTrailingImage.getHeight()
-                    - newTrailingImageHeight,
-                    BufferedImage.TYPE_INT_RGB);
+            BufferedImage newTrailingImage;
+            if ((oldTrailingImage.getHeight() == newTrailingImageHeight)) {
+                newTrailingImage = oldTrailingImage;
+            } else {
+                newTrailingImage = new BufferedImage(oldTrailingImage.getWidth(), oldTrailingImage.getHeight() - newTrailingImageHeight, BufferedImage.TYPE_INT_RGB);
+            }
 
             newTrailingImage.createGraphics().drawImage(oldTrailingImage, 0,
                     0 - newTrailingImageHeight, null);


### PR DESCRIPTION
Details:
 Fix an error with selenium screanshot:
Method threw 'java.lang.IllegalArgumentException' exception.
Width (1301) and height (0) cannot be <= 0



