### PR TITLE
[QATM-986] AssertCommandExistsOnTimeOut - Add positiblity of check exitStatus

### DIFF
--- a/src/main/java/com/stratio/qa/specs/ThenGSpec.java
+++ b/src/main/java/com/stratio/qa/specs/ThenGSpec.java
@@ -370,6 +370,8 @@ public class ThenGSpec extends BaseGSpec {
             try {
                 if (exitStatus != null) {
                     assertThat(commonspec.getRemoteSSHConnection().getExitStatus()).isEqualTo(exitStatus);
+                } else {
+                    assertThat(commonspec.getRemoteSSHConnection().getExitStatus()).isEqualTo(0);
                 }
                 assertThat(commonspec.getCommandResult()).as("Contains " + search + ".").contains(search);
                 found = true;

--- a/src/main/java/com/stratio/qa/specs/ThenGSpec.java
+++ b/src/main/java/com/stratio/qa/specs/ThenGSpec.java
@@ -355,11 +355,11 @@ public class ThenGSpec extends BaseGSpec {
      * @param search
      * @throws InterruptedException
      */
-    @Then("^in less than '(\\d+?)' seconds, checking each '(\\d+?)' seconds, the command output '(.+?)' contains '(.+?)'$")
-    public void assertCommandExistsOnTimeOut(Integer timeout, Integer wait, String command, String search) throws Exception {
+    @Then("^in less than '(\\d+?)' seconds, checking each '(\\d+?)' seconds, the command output '(.+?)' contains '(.+?)'( with exit status '(.+?)')?$")
+    public void assertCommandExistsOnTimeOut(Integer timeout, Integer wait, String command, String search, String foo, Integer exitStatus) throws Exception {
         Boolean found = false;
         AssertionError ex = null;
-
+        command = "set -o pipefail && alias grep='grep --color=never' && " + command;
         for (int i = 0; (i <= timeout); i += wait) {
             if (found) {
                 break;
@@ -368,6 +368,9 @@ public class ThenGSpec extends BaseGSpec {
             commonspec.getRemoteSSHConnection().runCommand(command);
             commonspec.setCommandResult(commonspec.getRemoteSSHConnection().getResult());
             try {
+                if (exitStatus != null) {
+                    assertThat(commonspec.getRemoteSSHConnection().getExitStatus()).isEqualTo(exitStatus);
+                }
                 assertThat(commonspec.getCommandResult()).as("Contains " + search + ".").contains(search);
                 found = true;
                 timeout = i;

--- a/src/test/java/com/stratio/qa/specs/ThenGIT.java
+++ b/src/test/java/com/stratio/qa/specs/ThenGIT.java
@@ -22,7 +22,7 @@ import org.testng.annotations.Test;
 import org.testng.annotations.Factory;
 import com.stratio.qa.data.BrowsersDataProvider;
 
-@CucumberOptions(format = "json:target/cucumber.json", features = {"src/test/resources/features/readWebElementTextToVariable.feature"})
+@CucumberOptions(format = "json:target/cucumber.json", features = {"src/test/resources/features/readWebElementTextToVariable.feature","src/test/resources/features/assertCommandExistsOnTimeOutIT.feature"})
 public class ThenGIT extends BaseTest {
 
     @Factory(enabled = false, dataProviderClass = BrowsersDataProvider.class, dataProvider = "availableUniqueBrowsers")

--- a/src/test/resources/features/assertCommandExistsOnTimeOutIT.feature
+++ b/src/test/resources/features/assertCommandExistsOnTimeOutIT.feature
@@ -1,0 +1,13 @@
+Feature: assertCommandExistsOnTimeOutIT - Check command output with exit status
+
+  Background: Connect to bootstrap machine
+    Given I open a ssh connection to '${SSH}' with user 'root' and password 'stratio'
+
+  Scenario: Check command output with correct expresion and exist status=0
+    Then in less than '50' seconds, checking each '10' seconds, the command output 'echo 2018 | grep -e "[0-9]\{4\}" | wc -l' contains '1' with exit status '0'
+
+  Scenario: Check with output  with incorrect expresion and exist status status!=0
+    Then in less than '50' seconds, checking each '10' seconds, the command output 'echo 2018 | grep -e "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{.*}}$ | wc -l' contains '1' with exit status '1'
+
+  Scenario: Check command output without exit status
+    Then in less than '50' seconds, checking each '10' seconds, the command output 'echo 2018 | grep -e "[0-9]\{4\}" | wc -l' contains '1'


### PR DESCRIPTION
Add posibility to check exitStatus in assertCommandExistsOnTimeOut method in order to control false positives.