### PR TITLE
[QATM-987] able to run or skip based on value, not existance

### DIFF
--- a/src/main/java/com/stratio/qa/aspects/RunOnTagAspect.java
+++ b/src/main/java/com/stratio/qa/aspects/RunOnTagAspect.java
@@ -127,8 +127,21 @@ public class RunOnTagAspect {
             throw new Exception("Error while parsing params. Params must be at least one");
         }
         for (int i = 0; i < params.length; i++) {
-            if (System.getProperty(params[i], "").isEmpty()) {
-                return false;
+            if (params[i].contains("=")) {
+                String param = params[i].split("=")[0];
+                String value = params[i].split("=")[1];
+
+                if (System.getProperty(param, "").isEmpty()) {
+                    return false;
+                }
+
+                if (!System.getProperty(param).equals(value)) {
+                    return false;
+                }
+            } else {
+                if (System.getProperty(params[i], "").isEmpty()) {
+                    return false;
+                }
             }
         }
         return true;

--- a/src/test/java/com/stratio/qa/aspects/RunOnEnvTagAspectTest.java
+++ b/src/test/java/com/stratio/qa/aspects/RunOnEnvTagAspectTest.java
@@ -65,6 +65,23 @@ public class RunOnEnvTagAspectTest {
     }
 
     @Test
+    public void testTagIterationRunArray() throws Exception {
+        System.setProperty("HELLO","OK");
+        System.setProperty("BYE","KO");
+        List<Tag> tagList = new ArrayList<>();
+        tagList.add(new Tag("@runOnEnv(HELLO,BYE)", 1));
+        assertThat(false).isEqualTo(runontag.tagsIteration(tagList,1));
+    }
+
+    @Test
+    public void testTagIterationRunArrayNegative() throws Exception {
+        System.setProperty("HELLO","OK");
+        List<Tag> tagList = new ArrayList<>();
+        tagList.add(new Tag("@runOnEnv(HELLO,BYE)", 1));
+        assertThat(false).isEqualTo(runontag.tagsIteration(tagList,1));
+    }
+
+    @Test
     public void testTagIterationIgnoreRun() throws Exception {
         List<Tag> tagList = new ArrayList<>();
         tagList.add(new Tag("@runOnEnv(BYE)", 1));
@@ -79,10 +96,190 @@ public class RunOnEnvTagAspectTest {
     }
 
     @Test
+    public void testTagIterationSkipArray() throws Exception {
+        List<Tag> tagList = new ArrayList<>();
+        tagList.add(new Tag("@skipOnEnv(HELLO_NO,BYE_NO)", 1));
+        assertThat(false).isEqualTo(runontag.tagsIteration(tagList,1));
+    }
+
+    @Test
     public void testTagIterationIgnoreSkip() throws Exception {
         System.setProperty("HELLO","OK");
         List<Tag> tagList = new ArrayList<>();
         tagList.add(new Tag("@skipOnEnv(HELLO)", 1));
         assertThat(true).isEqualTo(runontag.tagsIteration(tagList,1));
     }
+
+    @Test
+    public void testTagIterationIgnoreSkipArray() throws Exception {
+        System.setProperty("HELLO","OK");
+        System.setProperty("BYE","KO");
+        List<Tag> tagList = new ArrayList<>();
+        tagList.add(new Tag("@skipOnEnv(HELLO,BYE)", 1));
+        assertThat(true).isEqualTo(runontag.tagsIteration(tagList,1));
+    }
+
+    @Test
+    public void testTagIterationIgnoreSkipArrayNegative() throws Exception {
+        System.setProperty("HELLO","OK");
+        System.setProperty("BYE","KO");
+        List<Tag> tagList = new ArrayList<>();
+        tagList.add(new Tag("@skipOnEnv(HELLO,SEEYOU)", 1));
+        assertThat(false).isEqualTo(runontag.tagsIteration(tagList,1));
+    }
+
+    @Test
+    public void testTagIterationRunValue() throws Exception {
+        System.setProperty("HELLO","OK");
+        List<Tag> tagList = new ArrayList<>();
+        tagList.add(new Tag("@runOnEnv(HELLO=OK)", 1));
+        assertThat(false).isEqualTo(runontag.tagsIteration(tagList,1));
+    }
+
+    @Test
+    public void testTagIterationRunValueNotDefined() throws Exception {
+        List<Tag> tagList = new ArrayList<>();
+        tagList.add(new Tag("@runOnEnv(HELLO=OK)", 1));
+        assertThat(false).isEqualTo(runontag.tagsIteration(tagList,1));
+    }
+
+    @Test
+    public void testTagIterationRunValueNegative() throws Exception {
+        System.setProperty("HELLO","OK");
+        List<Tag> tagList = new ArrayList<>();
+        tagList.add(new Tag("@runOnEnv(HELLO=KO)", 1));
+        assertThat(true).isEqualTo(runontag.tagsIteration(tagList,1));
+    }
+
+    @Test
+    public void testTagIterationRunValueArray() throws Exception {
+        System.setProperty("HELLO","OK");
+        System.setProperty("BYE","KO");
+        List<Tag> tagList = new ArrayList<>();
+        tagList.add(new Tag("@runOnEnv(HELLO=OK,BYE=KO)", 1));
+        assertThat(false).isEqualTo(runontag.tagsIteration(tagList,1));
+    }
+
+    @Test
+    public void testTagIterationRunValueArrayNegative() throws Exception {
+        System.setProperty("HELLO","OK");
+        System.setProperty("BYE","KO");
+        List<Tag> tagList = new ArrayList<>();
+        tagList.add(new Tag("@runOnEnv(HELLO=OK,BYE=OK)", 1));
+        assertThat(true).isEqualTo(runontag.tagsIteration(tagList,1));
+    }
+
+    @Test
+    public void testTagIterationRunValueArrayMix() throws Exception {
+        System.setProperty("HELLO","OK");
+        System.setProperty("BYE","KO");
+        List<Tag> tagList = new ArrayList<>();
+        tagList.add(new Tag("@runOnEnv(HELLO=OK,BYE)", 1));
+        assertThat(false).isEqualTo(runontag.tagsIteration(tagList,1));
+    }
+
+    @Test
+    public void testTagIterationRunValueArrayMix2() throws Exception {
+        System.setProperty("HELLO","OK");
+        System.setProperty("BYE","KO");
+        List<Tag> tagList = new ArrayList<>();
+        tagList.add(new Tag("@runOnEnv(BYE,HELLO=OK)", 1));
+        assertThat(false).isEqualTo(runontag.tagsIteration(tagList,1));
+    }
+
+    @Test
+    public void testTagIterationRunValueArrayMixNegative() throws Exception {
+        System.setProperty("HELLO","OK");
+        System.setProperty("BYE","KO");
+        List<Tag> tagList = new ArrayList<>();
+        tagList.add(new Tag("@runOnEnv(HELLO=OK,SEEYOU)", 1));
+        assertThat(true).isEqualTo(runontag.tagsIteration(tagList,1));
+    }
+
+    @Test
+    public void testTagIterationRunValueArrayMixNegative2() throws Exception {
+        System.setProperty("HELLO","OK");
+        System.setProperty("BYE","KO");
+        List<Tag> tagList = new ArrayList<>();
+        tagList.add(new Tag("@runOnEnv(SEEYOU,HELLO=OK)", 1));
+        assertThat(true).isEqualTo(runontag.tagsIteration(tagList,1));
+    }
+
+    @Test
+    public void testTagIterationSkipValue() throws Exception {
+        System.setProperty("HELLO","OK");
+        List<Tag> tagList = new ArrayList<>();
+        tagList.add(new Tag("@skipOnEnv(HELLO=OK)", 1));
+        assertThat(true).isEqualTo(runontag.tagsIteration(tagList,1));
+    }
+
+    @Test
+    public void testTagIterationSkipValueNotDefined() throws Exception {
+        List<Tag> tagList = new ArrayList<>();
+        tagList.add(new Tag("@skipOnEnv(HELLO=OK)", 1));
+        assertThat(true).isEqualTo(runontag.tagsIteration(tagList,1));
+    }
+
+    @Test
+    public void testTagIterationSkipValueNegative() throws Exception {
+        System.setProperty("HELLO","OK");
+        List<Tag> tagList = new ArrayList<>();
+        tagList.add(new Tag("@skipOnEnv(HELLO=KO)", 1));
+        assertThat(false).isEqualTo(runontag.tagsIteration(tagList,1));
+    }
+
+    @Test
+    public void testTagIterationSkipValueArray() throws Exception {
+        System.setProperty("HELLO","OK");
+        System.setProperty("BYE","KO");
+        List<Tag> tagList = new ArrayList<>();
+        tagList.add(new Tag("@skipOnEnv(HELLO=OK,BYE=KO)", 1));
+        assertThat(true).isEqualTo(runontag.tagsIteration(tagList,1));
+    }
+
+    @Test
+    public void testTagIterationSkipValueArrayNegative() throws Exception {
+        System.setProperty("HELLO","OK");
+        System.setProperty("BYE","KO");
+        List<Tag> tagList = new ArrayList<>();
+        tagList.add(new Tag("@skipOnEnv(HELLO=OK,BYE=OK)", 1));
+        assertThat(false).isEqualTo(runontag.tagsIteration(tagList,1));
+    }
+
+    @Test
+    public void testTagIterationSkipValueArrayMix() throws Exception {
+        System.setProperty("HELLO","OK");
+        System.setProperty("BYE","KO");
+        List<Tag> tagList = new ArrayList<>();
+        tagList.add(new Tag("@skipOnEnv(HELLO=OK,BYE)", 1));
+        assertThat(true).isEqualTo(runontag.tagsIteration(tagList,1));
+    }
+
+    @Test
+    public void testTagIterationSkipValueArrayMix2() throws Exception {
+        System.setProperty("HELLO","OK");
+        System.setProperty("BYE","KO");
+        List<Tag> tagList = new ArrayList<>();
+        tagList.add(new Tag("@skipOnEnv(BYE,HELLO=OK)", 1));
+        assertThat(true).isEqualTo(runontag.tagsIteration(tagList,1));
+    }
+
+    @Test
+    public void testTagIterationSkipValueArrayMixNegative() throws Exception {
+        System.setProperty("HELLO","OK");
+        System.setProperty("BYE","KO");
+        List<Tag> tagList = new ArrayList<>();
+        tagList.add(new Tag("@skipOnEnv(HELLO=OK,SEEYOU)", 1));
+        assertThat(false).isEqualTo(runontag.tagsIteration(tagList,1));
+    }
+
+    @Test
+    public void testTagIterationSkipValueArrayMixNegative2() throws Exception {
+        System.setProperty("HELLO","OK");
+        System.setProperty("BYE","KO");
+        List<Tag> tagList = new ArrayList<>();
+        tagList.add(new Tag("@skipOnEnv(SEEYOU,HELLO=OK)", 1));
+        assertThat(false).isEqualTo(runontag.tagsIteration(tagList,1));
+    }
+
 }


### PR DESCRIPTION
With this change we can make it easier to install different versions of a package using the config file, checking for the value of parameter VERSION:

Example:
Feature: Install framework

@runOnEnv(VERSION=1.0.0)
Scenario: Prepare config file
...
And I create file 'config.json' based on 'schemas/eos-kafka-framework_config_${VERSION}.json' as 'json' with:
      | $.specific.parameter.version.1.0.0                         | UPDATE  | ${KEY:-value}      | n/a |
...
@runOnEnv(VERSION=1.1.0)
Scenario: Prepare config file
...
And I create file 'config.json' based on 'schemas/eos-kafka-framework_config_${VERSION}.json' as 'json' with:
      | $.specific.parameter.version.1.1.0                         | UPDATE  | ${KEY:-value}      | n/a |
...

Scenario: Install using dcos-cli
When I run 'dcos package install --package-version=${VERSION} --options=/tmp/config.json ${PACKAGE:-eos-kafka-framework}' in the ssh connection
...
