### PR TITLE
[QATM-988] add possibility to add fields to json with type

### DIFF
--- a/src/main/java/com/stratio/qa/specs/CommonG.java
+++ b/src/main/java/com/stratio/qa/specs/CommonG.java
@@ -825,8 +825,49 @@ public class CommonG {
                             newKey = composeKey;
                             newComposeKey = "$";
                         }
-                        jsonAsMap = JsonPath.parse(modifiedData).put(newComposeKey, newKey, newValue).json();
-                        break;
+
+                        if ("array".equals(typeJsonObject)) {
+                            jArray = new JSONArray();
+                            if (!"[]".equals(newValue)) {
+                                jArray = new JSONArray(newValue);
+                            }
+                            jsonAsMap = JsonPath.parse(modifiedData).put(newComposeKey, newKey, jArray).json();
+                            break;
+                        } else if ("object".equals(typeJsonObject)) {
+                            jObject = new JSONObject();
+                            if (!"{}".equals(newValue)) {
+                                jObject = new JSONObject(newValue);
+                            }
+                            jsonAsMap = JsonPath.parse(modifiedData).put(newComposeKey, newKey, jObject).json();
+                            break;
+                        } else if ("string".equals(typeJsonObject)) {
+                            jsonAsMap = JsonPath.parse(modifiedData).put(newComposeKey, newKey, newValue).json();
+                            break;
+
+                        } else if ("number".equals(typeJsonObject)) {
+                            jNumber = new Double(newValue);
+                            jsonAsMap = JsonPath.parse(modifiedData).put(newComposeKey, newKey, jNumber).json();
+                            break;
+
+                        } else if ("boolean".equals(typeJsonObject)) {
+                            jBoolean = new Boolean(newValue);
+                            jsonAsMap = JsonPath.parse(modifiedData).put(newComposeKey, newKey, jBoolean).json();
+                            break;
+
+                        } else if ("null".equals(typeJsonObject)) {
+                            nullValue = JsonPath.parse(modifiedData).put(newComposeKey, newKey, null).jsonString();
+                            break;
+
+                        } else {
+                            String replaceValue = JsonPath.parse(modifiedData).read(composeKey);
+                            String toBeReplaced = newValue.split("->")[0];
+                            String replacement = newValue.split("->")[1];
+                            newValue = replaceValue.replace(toBeReplaced, replacement);
+                            jsonAsMap = JsonPath.parse(modifiedData).put(newComposeKey, newKey, newValue).json();
+                            break;
+                        }
+//                        jsonAsMap = JsonPath.parse(modifiedData).put(newComposeKey, newKey, newValue).json();
+//                        break;
                     case "UPDATE":
                         jsonAsMap = JsonPath.parse(modifiedData).set(composeKey, newValue).json();
                         break;

--- a/src/test/java/com/stratio/qa/specs/CommonGTest.java
+++ b/src/test/java/com/stratio/qa/specs/CommonGTest.java
@@ -371,7 +371,7 @@ public class CommonGTest {
         String data = jsonObject1.toString();
         String expectedData = jsonObject6.toString();
         String type = "json";
-        List<List<String>> rawData = Arrays.asList(Arrays.asList("$.key2.key4", "ADD", "value4"));
+        List<List<String>> rawData = Arrays.asList(Arrays.asList("$.key2.key4", "ADD", "value4", "string"));
         DataTable modifications = DataTable.create(rawData);
 
         String modifiedData = commong.modifyData(data, type, modifications);

--- a/src/test/resources/features/jsonReplacements.feature
+++ b/src/test/resources/features/jsonReplacements.feature
@@ -46,8 +46,8 @@ Feature: JSON replacements
     Given I run 'ls' locally
     Given I create file 'testSOATtag.json' based on 'schemas/simple1.json' as 'json' with:
       | $.a         | REPLACE | @{JSON.schemas/<file>.json}     | object   |
-      | b           | ADD     | ${WAIT}                         | N/A      |
-      | ${WAIT}     | ADD     | @{JSON.schemas/<file>.json}     | object   |
+      | $.b         | ADD     | ${WAIT}                         | number   |
+      | $.${WAIT}   | ADD     | @{JSON.schemas/<file>.json}     | object   |
     Given I save '@{JSON.testSOATtag.json}' in variable 'VAR'
     Then I run '[ "!{VAR}" = "<content>" ]' locally
 


### PR DESCRIPTION
When modifying data in a json, we need the option to add new fields to the json of a specific type:

{"key1": "value1", "key2": "value2"}
| $.newkey | ADD | true | string | -> {"key1": "value1", "key2": "value2", "newkey": "true"}
| $.newkey | ADD | {} | object | -> {"key1": "value1", "key2": "value2", "newkey": {}}
| $.newkey | ADD | true | boolean | -> {"key1": "value1", "key2": "value2", "newkey": true}
| $.newkey | ADD | 3 | number | -> {"key1": "value1", "key2": "value2", "newkey": 3}

