### PR TITLE
[QATM-1042] Add remove method

### DIFF
--- a/src/main/java/com/stratio/qa/utils/ThreadProperty.java
+++ b/src/main/java/com/stratio/qa/utils/ThreadProperty.java
@@ -50,4 +50,12 @@ public final class ThreadProperty {
     public static String get(String key) {
         return PROPS.get().getProperty(key);
     }
+
+    /**
+     * Remove a property shared
+     */
+    public static void remove(String key) {
+        PROPS.get().remove(key);
+    }
+
 }


### PR DESCRIPTION
We would need to implement a clear method in ThreadLocal class in order to clean ThreadProperty object after each step execution. We have observed after launching two steps that make use of the method selectData (I query the database with , for example), if the first one have more columns that second one, the first result overlaps the last.