### PR TITLE
[PIT-68] Updated commons-lang3 version to 3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Only listing significant user-visible, not internal code cleanups and minor bug 
 ## 0.8.0 (upcoming)
 
 * [QATM-967] Updated Selenium version to 3.9.1
+* [PIT-68] Updated commons-lang3 version to 3.7
 
 ## 0.7.0 (April 05, 2018)
 

--- a/pom.xml
+++ b/pom.xml
@@ -424,7 +424,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.1</version>
+            <version>3.7</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Updated commons-lang3 version to 3.7.
Crossdata testsAT are failing due to this issue.