### PR TITLE
[QATM-1431] Add sql steps to bdt

### DIFF
--- a/src/main/java/com/stratio/qa/specs/CommonG.java
+++ b/src/main/java/com/stratio/qa/specs/CommonG.java
@@ -130,7 +130,7 @@ public class CommonG {
 
     private Optional<SearchResult> previousLdapResults;
 
-    Connection myConnection = null;
+    private Connection myConnection = null;
 
     /**
      * Checks if a given string matches a regular expression or contains a string

--- a/src/main/java/com/stratio/qa/specs/CommonG.java
+++ b/src/main/java/com/stratio/qa/specs/CommonG.java
@@ -130,6 +130,8 @@ public class CommonG {
 
     private Optional<SearchResult> previousLdapResults;
 
+    Connection myConnection = null;
+
     /**
      * Checks if a given string matches a regular expression or contains a string
      *
@@ -2004,8 +2006,6 @@ public class CommonG {
      */
     public void connectToPostgreSQLDatabase(String database, String host, String port, String user, String password, Boolean secure, String ca, String crt, String key) throws SQLException {
 
-        Connection myConnection = null;
-
         if (port.startsWith("[")) {
             port = port.substring(1, port.length() - 1);
         }
@@ -2054,6 +2054,14 @@ public class CommonG {
             }
 
         }
+    }
+
+    /*
+     * @return connection object
+     *
+     */
+    public Connection getConnection() {
+        return this.myConnection;
     }
 
 }

--- a/src/main/java/com/stratio/qa/specs/ThenGSpec.java
+++ b/src/main/java/com/stratio/qa/specs/ThenGSpec.java
@@ -32,7 +32,6 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Fail;
 import org.assertj.core.api.WritableAssertionInfo;
 import org.json.JSONArray;
-import org.ldaptive.LdapAttribute;
 import org.openqa.selenium.WebElement;
 
 import java.sql.Connection;
@@ -46,6 +45,7 @@ import static org.testng.AssertJUnit.fail;
 
 /**
  * Generic Then Specs.
+ *
  * @see <a href="ThenGSpec-annotations.html">Then Steps &amp; Matching Regex</a>
  */
 public class ThenGSpec extends BaseGSpec {
@@ -502,7 +502,7 @@ public class ThenGSpec extends BaseGSpec {
                     assertThat(r.getStatusCode()).isEqualTo(expectedStatus);
                     assertThat((new JSONArray(r.getResponse())).length()).isEqualTo(expectedLength);
                 });
-            } else  if (foo.contains("text")) {
+            } else if (foo.contains("text")) {
                 WritableAssertionInfo assertionInfo = new WritableAssertionInfo();
                 Pattern pattern = CommonG.matchesOrContains(expectedText);
                 assertThat(Optional.of(commonspec.getResponse())).hasValueSatisfying(r -> {
@@ -650,7 +650,7 @@ public class ThenGSpec extends BaseGSpec {
      * @param document expected content of znode
      */
     @Then("^the zNode '(.+?)' exists( and contains '(.+?)')?$")
-    public void checkZnodeExists(String zNode, String foo, String document)  throws Exception {
+    public void checkZnodeExists(String zNode, String foo, String document) throws Exception {
         if (document == null) {
             String breakpoint = commonspec.getZookeeperSecClient().zRead(zNode);
             assert breakpoint.equals("") : "The zNode does not exist";
@@ -810,7 +810,8 @@ public class ThenGSpec extends BaseGSpec {
 
     /**
      * Takes the content of a webElement and stores it in the thread environment variable passed as parameter
-     * @param index position of the element in the array of webElements found
+     *
+     * @param index  position of the element in the array of webElements found
      * @param envVar name of the thread environment variable where to store the text
      */
     @Then("^I save content of element in index '(\\d+?)' in environment variable '(.+?)'$")
@@ -910,16 +911,16 @@ public class ThenGSpec extends BaseGSpec {
         java.sql.ResultSet rs = null;
 
         //from postgres table
-        List<String> sqlTable =  new ArrayList<String>();
-        List<String> sqlTableAux =  new ArrayList<String>();
+        List<String> sqlTable = new ArrayList<String>();
+        List<String> sqlTableAux = new ArrayList<String>();
         //from Cucumber Datatable
-        List<String> tablePattern =  new ArrayList<String>();
+        List<String> tablePattern = new ArrayList<String>();
         //comparison is by lists of string
         tablePattern = dataTable.asList(String.class);
 
 
         Connection myConnection = this.commonspec.getConnection();
-        String query = "SELECT * FROM "+ tableName  + " order by " +  "id" + ";";
+        String query = "SELECT * FROM " + tableName + " order by " + "id" + ";";
         try {
             myStatement = myConnection.createStatement();
             rs = myStatement.executeQuery(query);
@@ -968,19 +969,20 @@ public class ThenGSpec extends BaseGSpec {
     public void comparetable(DataTable dataTable) throws Exception {
 
         //from Cucumber Datatable, the pattern to verify
-        List<String> tablePattern =  new ArrayList<String>();
+        List<String> tablePattern = new ArrayList<String>();
         tablePattern = dataTable.asList(String.class);
         //the result from select
-        List<String> sqlTable =  new ArrayList<String>();
+        List<String> sqlTable = new ArrayList<String>();
 
         //the result is taken from previous step
         for (int i = 0; ThreadProperty.get("queryresponse" + i) != null; i++) {
-            String ip_value = ThreadProperty.get("queryresponse"+i);
-            sqlTable.add(i,ip_value);
+            String ip_value = ThreadProperty.get("queryresponse" + i);
+            sqlTable.add(i, ip_value);
         }
 
-        for (int i = 0; ThreadProperty.get("queryresponse" + i) != null; i++)
-            ThreadProperty.remove("queryresponse"+i);
+        for (int i = 0; ThreadProperty.get("queryresponse" + i) != null; i++) {
+            ThreadProperty.remove("queryresponse" + i);
+        }
 
         assertThat(tablePattern).as("response is not equal to the expected").isEqualTo(sqlTable);
     }

--- a/src/main/java/com/stratio/qa/specs/ThenGSpec.java
+++ b/src/main/java/com/stratio/qa/specs/ThenGSpec.java
@@ -35,6 +35,9 @@ import org.json.JSONArray;
 import org.ldaptive.LdapAttribute;
 import org.openqa.selenium.WebElement;
 
+import java.sql.Connection;
+import java.sql.ResultSetMetaData;
+import java.sql.Statement;
 import java.util.*;
 import java.util.regex.Pattern;
 
@@ -831,8 +834,155 @@ public class ThenGSpec extends BaseGSpec {
         } else {
             fail("No previous LDAP results were stored in memory");
         }
+    }
+
+    /*
+     * @param table
+     * checks table existence
+     *
+     */
+    @Then("^table '(.+?)' exists$")
+    public void checkTable(String tableName) throws Exception {
+        Statement myStatement = null;
+        Connection myConnection = this.commonspec.getConnection();
+
+        //query checks table existence, existence table name in system table  pg_tables
+        String query = "SELECT * FROM pg_tables WHERE tablename = " + "\'" + tableName + "\'" + ";";
+        try {
+            myStatement = myConnection.createStatement();
+            java.sql.ResultSet rs = myStatement.executeQuery(query);
+            //if there are no data row
+            if (rs.next() == false) {
+                Assertions.assertThat(rs.next()).as("there are no table " + tableName).isTrue();
+            } else {
+                //data exist
+                String resultTableName = rs.getString(2);
+                assertThat(resultTableName).as("there are incorrect table name " + tableName).contains(tableName);
+            }
+            rs.close();
+            myStatement.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+    }
 
 
+    /*
+     * @param table
+     * checks table existence negative case
+     *
+     */
+    @Then("^table '(.+?)' doesn't exists$")
+    public void checkTableFalse(String tableName) throws Exception {
+        Statement myStatement = null;
+        Connection myConnection = this.commonspec.getConnection();
+
+        String query = "SELECT * FROM pg_tables WHERE tablename = " + "\'" + tableName + "\'" + ";";
+        try {
+            myStatement = myConnection.createStatement();
+            java.sql.ResultSet rs = myStatement.executeQuery(query);
+            //if there are no data row, table doesn't exists
+            if (rs.next() == false) {
+                Assertions.assertThat(rs.next()).as("table exists " + tableName).isFalse();
+            } else {
+                String resultTableName = rs.getString(2);
+                assertThat(resultTableName).as("table exists " + tableName).isEqualToIgnoringCase(tableName);
+            }
+            rs.close();
+            myStatement.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+
+    /*
+     * @param tableName
+     * @param dataTable
+     * compares two tables: pattern table and the result from remote database
+     * by default: order by id
+     *
+     */
+    @Then("^I check that table '(.+?)' is iqual to$")
+    public void comparetable(String tableName, DataTable dataTable) throws Exception {
+        Statement myStatement = null;
+        java.sql.ResultSet rs = null;
+
+        //from postgres table
+        List<String> sqlTable =  new ArrayList<String>();
+        List<String> sqlTableAux =  new ArrayList<String>();
+        //from Cucumber Datatable
+        List<String> tablePattern =  new ArrayList<String>();
+        //comparison is by lists of string
+        tablePattern = dataTable.asList(String.class);
+
+
+        Connection myConnection = this.commonspec.getConnection();
+        String query = "SELECT * FROM "+ tableName  + " order by " +  "id" + ";";
+        try {
+            myStatement = myConnection.createStatement();
+            rs = myStatement.executeQuery(query);
+
+            //takes column names and culumn count
+            ResultSetMetaData resultSetMetaData = rs.getMetaData();
+            int count = resultSetMetaData.getColumnCount();
+            for (int i = 1; i <= count; i++) {
+                sqlTable.add(resultSetMetaData.getColumnName(i).toString());
+            }
+
+            //takes column names and culumn count
+            while (rs.next()) {
+                for (int i = 1; i <= count; i++) {
+                    //aux list without column names
+                    sqlTableAux.add(rs.getObject(i).toString());
+                }
+            }
+            sqlTable.addAll(sqlTableAux);
+
+            assertThat(sqlTable).as("Not equal elements!").isEqualTo(tablePattern);
+            rs.close();
+            myStatement.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertThat(rs).as("There are no table " + tableName).isNotNull();
+        }
+
+    }
+
+    /*
+     * closes opened database
+     *
+     */
+    @Then("^I close database connection$")
+    public void connectDatabase() throws Exception {
+        this.commonspec.getConnection().close();
+    }
+
+    /*
+     * @param tableName
+     * checks the result from select
+     *
+     */
+    @Then("^I check that result is:$")
+    public void comparetable(DataTable dataTable) throws Exception {
+
+        //from Cucumber Datatable, the pattern to verify
+        List<String> tablePattern =  new ArrayList<String>();
+        tablePattern = dataTable.asList(String.class);
+        //the result from select
+        List<String> sqlTable =  new ArrayList<String>();
+
+        //the result is taken from previous step
+        for (int i = 0; ThreadProperty.get("queryresponse" + i) != null; i++) {
+            String ip_value = ThreadProperty.get("queryresponse"+i);
+            sqlTable.add(i,ip_value);
+        }
+
+        for (int i = 0; ThreadProperty.get("queryresponse" + i) != null; i++)
+            ThreadProperty.remove("queryresponse"+i);
+
+        assertThat(tablePattern).as("response is not equal to the expected").isEqualTo(sqlTable);
     }
 }
 

--- a/src/main/java/com/stratio/qa/specs/WhenGSpec.java
+++ b/src/main/java/com/stratio/qa/specs/WhenGSpec.java
@@ -17,6 +17,7 @@
 package com.stratio.qa.specs;
 
 import com.csvreader.CsvReader;
+import com.datastax.driver.core.ResultSet;
 import com.mongodb.DBCollection;
 import com.mongodb.DBCursor;
 import com.mongodb.DBObject;
@@ -28,12 +29,10 @@ import com.stratio.qa.utils.ThreadProperty;
 import cucumber.api.DataTable;
 import cucumber.api.Transform;
 import cucumber.api.java.en.When;
-import org.apache.zookeeper.KeeperException;
 import org.assertj.core.api.Assertions;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.hjson.JsonArray;
 import org.hjson.JsonValue;
-import org.json.JSONObject;
 import org.ldaptive.SearchRequest;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
@@ -45,15 +44,12 @@ import java.io.*;
 import java.sql.Connection;
 import java.sql.ResultSetMetaData;
 import java.sql.Statement;
-import java.sql.Time;
 import java.util.*;
 import java.util.concurrent.Future;
 import java.util.regex.Pattern;
 
 import static com.stratio.qa.assertions.Assertions.assertThat;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
-
-import com.datastax.driver.core.ResultSet;
 
 
 /**
@@ -143,7 +139,6 @@ public class WhenGSpec extends BaseGSpec {
     }
 
 
-
     /**
      * Delete or replace the text on a numbered {@code index} previously found element.
      *
@@ -169,8 +164,6 @@ public class WhenGSpec extends BaseGSpec {
             actions.build().perform();
         }
     }
-
-
 
 
     /**
@@ -918,7 +911,7 @@ public class WhenGSpec extends BaseGSpec {
 
     /**
      * Method to convert one json to yaml file - backup&restore functionality
-     *
+     * <p>
      * File will be placed on path /target/test-classes
      */
     @When("^I convert the json file '(.+?)' to yaml file '(.+?)'$")
@@ -952,7 +945,7 @@ public class WhenGSpec extends BaseGSpec {
      *
      */
     @When("^I execute query '(.+?)'$")
-    public void executeQuery(String query) throws Exception{
+    public void executeQuery(String query) throws Exception {
         Statement myStatement = null;
         int result = 0;
         Connection myConnection = this.commonspec.getConnection();
@@ -974,11 +967,11 @@ public class WhenGSpec extends BaseGSpec {
      *
      */
     @When("^I query the database with '(.+?)'$")
-    public void selectData(String query) throws Exception{
+    public void selectData(String query) throws Exception {
         Statement myStatement = null;
         //postgres table
-        List<String> sqlTable =  new ArrayList<String>();
-        List<String> sqlTableAux =  new ArrayList<String>();
+        List<String> sqlTable = new ArrayList<String>();
+        List<String> sqlTableAux = new ArrayList<String>();
         Connection myConnection = this.commonspec.getConnection();
         java.sql.ResultSet rs = null;
         try {
@@ -1000,8 +993,8 @@ public class WhenGSpec extends BaseGSpec {
             sqlTable.addAll(sqlTableAux);
 
             //sends raws to environment variable
-            for (int i = 0; i<sqlTable.size(); i++) {
-                ThreadProperty.set("queryresponse"+i, sqlTable.get(i));
+            for (int i = 0; i < sqlTable.size(); i++) {
+                ThreadProperty.set("queryresponse" + i, sqlTable.get(i));
             }
             rs.close();
             myStatement.close();


### PR DESCRIPTION
New steps added to bdt
- I execute query %
- I query the database with %
- table '(.+?)' exists
- table '(.+?)' doesn't exists
- I check that table '(.+?)' is iqual to $
- I close database connection
- ^I check that result is:$