### PR TITLE
[QATM-1689] Sustituir en la conexion a base de datos securely por el tipo de seguridad 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ target/*
 _ajdump/
 testOutput.txt
 testMultiloopOutput*.txt
+*.crt
+*.key
+*.keytab
+*.pem

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,8 @@ target/*
 _ajdump/
 testOutput.txt
 testMultiloopOutput*.txt
+*.crt
+*.pem
+*.key
+*.keytab
+

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ target/*
 *.log
 _ajdump/
 testOutput.txt
-
+testMultiloopOutput*.txt

--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,4 @@ target/*
 *.log
 _ajdump/
 testOutput.txt
-testMultiloopOutput*.txt
-*.crt
-*.pem
-*.key
-*.keytab
 

--- a/src/main/java/com/stratio/qa/specs/CommonG.java
+++ b/src/main/java/com/stratio/qa/specs/CommonG.java
@@ -2040,9 +2040,6 @@ public class CommonG {
             if (user != null) {
                 props.setProperty("user", user);
             }
-            if (password != null) {
-                props.setProperty("password", user);
-            }
             if (ca != null) {
                 props.setProperty("sslrootcert", ca);
             }
@@ -2052,7 +2049,7 @@ public class CommonG {
             if (key != null) {
                 props.setProperty("sslkey", key);
             }
-
+            props.setProperty("password", "null");
             props.setProperty("ssl", "true");
             props.setProperty("sslmode", "verify-full");
 

--- a/src/main/java/com/stratio/qa/specs/GivenGSpec.java
+++ b/src/main/java/com/stratio/qa/specs/GivenGSpec.java
@@ -1044,10 +1044,10 @@ public class GivenGSpec extends BaseGSpec {
      * @param key:      database private key
      * @throws Exception exception     *
      */
-    @Given("^I( securely)? connect with JDBC to database '(.+?)' on host '(.+?)' and port '(.+?)' with user '(.+?)'( and password '(.+?)')?( and root ca '(.+?)')?(, crt '(.+?)')?( and key '(.+?)' certificates)?$")
-    public void connectDatabasePostgres(String isSecured, String database, String host, String port, String user, String foo, String password, String foo1, String ca, String foo2, String crt, String foo3, String key) throws Exception {
+    @Given("^I( securely)? connect with JDBC( with security type '(TLS|MD5|TRUST|cert|md5|ldap)')? to database '(.+?)' on host '(.+?)' and port '(.+?)' with user '(.+?)'( and password '(.+?)')?( and root ca '(.+?)')?(, crt '(.+?)')?( and key '(.+?)' certificates)?$")
+    public void connectDatabasePostgres(String isSecured, String foo, String securityType, String database, String host, String port, String user, String foo1, String password, String foo2, String ca, String foo3, String crt, String foo4, String key) throws Exception {
         this.commonspec.getExceptions().clear();
-        if (isSecured != null) {
+        if ((isSecured != null && securityType == null) || "TLS".equals(securityType) || "cert".equals(securityType)) {
             commonspec.getLogger().debug("opening secure database");
             try {
                 this.commonspec.connectToPostgreSQLDatabase(database, host, port, user, password, true, ca, crt, key);

--- a/src/main/java/com/stratio/qa/specs/GivenGSpec.java
+++ b/src/main/java/com/stratio/qa/specs/GivenGSpec.java
@@ -1033,7 +1033,6 @@ public class GivenGSpec extends BaseGSpec {
     /**
      * Connect to JDBC secured/not secured database
      *
-     * @param isSecured if the database is secured (TLS) or not
      * @param database  database connection string
      * @param host      database host
      * @param port      database port
@@ -1044,10 +1043,10 @@ public class GivenGSpec extends BaseGSpec {
      * @param key:      database private key
      * @throws Exception exception     *
      */
-    @Given("^I( securely)? connect with JDBC( with security type '(TLS|MD5|TRUST|cert|md5|ldap)')? to database '(.+?)' on host '(.+?)' and port '(.+?)' with user '(.+?)'( and password '(.+?)')?( and root ca '(.+?)')?(, crt '(.+?)')?( and key '(.+?)' certificates)?$")
-    public void connectDatabasePostgres(String isSecured, String foo, String securityType, String database, String host, String port, String user, String foo1, String password, String foo2, String ca, String foo3, String crt, String foo4, String key) throws Exception {
+    @Given("^I connect with JDBC and security type '(TLS|MD5|TRUST|CERT|LDAP|tls|md5|trust|cert|ldap)' to database '(.+?)' on host '(.+?)' and port '(.+?)' with user '(.+?)'( and password '(.+?)')?( and root ca '(.+?)')?(, crt '(.+?)')?( and key '(.+?)' certificates)?$")
+    public void connectDatabasePostgres(String securityType, String database, String host, String port, String user, String foo1, String password, String foo2, String ca, String foo3, String crt, String foo4, String key) throws Exception {
         this.commonspec.getExceptions().clear();
-        if ((isSecured != null && securityType == null) || "TLS".equals(securityType) || "cert".equals(securityType)) {
+        if ("TLS".equals(securityType) || "tls".equals(securityType) || "CERT".equals(securityType) || "cert".equals(securityType)) {
             commonspec.getLogger().debug("opening secure database");
             try {
                 this.commonspec.connectToPostgreSQLDatabase(database, host, port, user, password, true, ca, crt, key);


### PR DESCRIPTION
Se ha eliminado del step de conexión a base de datos la palabra securely y se ha incluido el tipo de seguridad.