### PR TITLE
[QATM-1842] Corregir error result por return en checkParams al tener operadores logicos

### DIFF
--- a/src/main/java/com/stratio/qa/aspects/RunOnTagAspect.java
+++ b/src/main/java/com/stratio/qa/aspects/RunOnTagAspect.java
@@ -212,22 +212,22 @@ public class RunOnTagAspect {
                 String param = params[0][0].split(">")[0];
                 String value = params[0][0].split(">")[1];
                 if (System.getProperty(param, "").isEmpty()) {
-                    return false;
+                    result =  false;
                 }
 
                 if (!(value.compareTo(System.getProperty(param)) < 0)) {
-                    return false;
+                    result = false;
                 }
             } else if (params[0][0].contains("<")) {
                 String param = params[0][0].split("<")[0];
                 String value = params[0][0].split("<")[1];
 
                 if (System.getProperty(param, "").isEmpty()) {
-                    return false;
+                    result = false;
                 }
 
                 if (!(value.compareTo(System.getProperty(param)) > 0)) {
-                    return false;
+                    result = false;
                 }
             } else {
                 if (System.getProperty(params[0][0], "").isEmpty()) {


### PR DESCRIPTION
Se corrige un error en RunOnTagAspect en la funcion checkParams, en vez de return era result=