### PR TITLE
[QATM-2178] Creación step para la comprobación de constraints de un role de un servicio de una instancia determinada

### DIFF
--- a/src/main/java/com/stratio/qa/specs/DcosSpec.java
+++ b/src/main/java/com/stratio/qa/specs/DcosSpec.java
@@ -641,9 +641,7 @@ public class DcosSpec extends BaseGSpec {
                 }
                 Iterator it = diferent.keySet().iterator();
                 while (it.hasNext()) {
-                    if (diferent.get(it.next()) > Integer.parseInt(value)) {
-                        throw new Exception("The role " + role + " of the instance " + instance + " doesn't complies the established constraint " + tag + ":" + constraint + ":" + value);
-                    }
+                    Assertions.assertThat(diferent.get(it.next())).overridingErrorMessage("The role " + role + " of the instance " + instance + " doesn't complies the established constraint " + tag + ":" + constraint + ":" + value).isLessThanOrEqualTo(Integer.parseInt(value));
                 }
                 break;
             case "GROUP_BY":
@@ -662,12 +660,10 @@ public class DcosSpec extends BaseGSpec {
                         dif.add(elements[i]);
                     }
                 }
-                if (dif.size() > Integer.parseInt(value)) {
-                    throw new Exception("The role " + role + " of the instance " + instance + " doesn't complies the established constraint " + tag + ":" + constraint + ":" + value);
-                }
-                break;
+               Assertions.assertThat(dif.size()).overridingErrorMessage("The role " + role + " of the instance " + instance + " doesn't complies the established constraint " + tag + ":" + constraint + ":" + value).isLessThanOrEqualTo(Integer.parseInt(value));
+               break;
             default:
-                throw new Exception("Error while parsing constraints. Constraints should be CLUSTER, UNIQUE, LIKE, UNLIKE, GROUP_BY, UNIQUE, LIKE, UNLIKE, GROUP_BY, MAX_PER or IS");
+                commonspec.getExceptions().add(new Exception("Error while parsing constraints. Constraints should be CLUSTER, UNIQUE, LIKE, UNLIKE, GROUP_BY, UNIQUE, LIKE, UNLIKE, GROUP_BY, MAX_PER or IS"));
         }
     }
 

--- a/src/main/java/com/stratio/qa/specs/DcosSpec.java
+++ b/src/main/java/com/stratio/qa/specs/DcosSpec.java
@@ -660,8 +660,8 @@ public class DcosSpec extends BaseGSpec {
                         dif.add(elements[i]);
                     }
                 }
-               Assertions.assertThat(dif.size()).overridingErrorMessage("The role " + role + " of the instance " + instance + " doesn't complies the established constraint " + tag + ":" + constraint + ":" + value).isLessThanOrEqualTo(Integer.parseInt(value));
-               break;
+                Assertions.assertThat(dif.size()).overridingErrorMessage("The role " + role + " of the instance " + instance + " doesn't complies the established constraint " + tag + ":" + constraint + ":" + value).isLessThanOrEqualTo(Integer.parseInt(value));
+                break;
             default:
                 commonspec.getExceptions().add(new Exception("Error while parsing constraints. Constraints should be CLUSTER, UNIQUE, LIKE, UNLIKE, GROUP_BY, UNIQUE, LIKE, UNLIKE, GROUP_BY, MAX_PER or IS"));
         }


### PR DESCRIPTION
Se ha creado un nuevo step en la librería:

The role '<role>' of the service '<service>' with instance '<instance>' complies the constraints '<constraint>'

<role> es el role de los nodos a comprobar si cumplen una constraint

<service> es el servicio perteneciente al nombre de ese servicio en el exhibitor

<instance> nombre con el que se desplegó el servicio

<constraint> pueden ser una o varias constraints separadas por “,”