### PR TITLE
[QATM-2303] refactor of steps due to new cucumber version

### DIFF
--- a/src/main/java/com/stratio/qa/specs/RestSpec.java
+++ b/src/main/java/com/stratio/qa/specs/RestSpec.java
@@ -224,14 +224,14 @@ public class RestSpec extends BaseGSpec {
 
     @When("^I create '(policy|user|group)' '(.+?)' using API service path '(.+?)'( with user and password '(.+:.+?)')? based on '([^:]+?)'( as '(json|string|gov)')? with:$")
     public void createResource(String resource, String resourceId, String endPoint, String loginInfo, String baseData, String type, DataTable modifications) throws Exception {
-        createResourceIfNotExist(resource, resourceId, endPoint, loginInfo, null, baseData, type, modifications);
+        createResourceIfNotExist(resource, resourceId, endPoint, loginInfo, false, baseData, type, modifications);
 
     }
 
 
     @When("^I create '(policy|user|group)' '(.+?)' using API service path '(.+?)'( with user and password '(.+:.+?)')? if it does not exist based on '([^:]+?)'( as '(json|string|gov)')? with:$")
     public void createResourceIfNotExist(String resource, String resourceId, String endPoint, String loginInfo, String baseData, String type, DataTable modifications) throws Exception {
-        createResourceIfNotExist(resource, resourceId, endPoint, loginInfo, "true", baseData, type, modifications);
+        createResourceIfNotExist(resource, resourceId, endPoint, loginInfo, true, baseData, type, modifications);
     }
 
 
@@ -248,7 +248,7 @@ public class RestSpec extends BaseGSpec {
      * @param modifications
      * @throws Exception
      */
-    private void createResourceIfNotExist(String resource, String resourceId, String endPoint, String loginInfo, String doesNotExist, String baseData, String type, DataTable modifications) throws Exception {
+    private void createResourceIfNotExist(String resource, String resourceId, String endPoint, String loginInfo, boolean doesNotExist, String baseData, String type, DataTable modifications) throws Exception {
         Integer expectedStatusCreate = new Integer(201);
         Integer expectedStatusDelete = new Integer(200);
         String endPointResource = endPoint + "/" + resourceId;
@@ -274,7 +274,7 @@ public class RestSpec extends BaseGSpec {
             } else {
                 commonspec.getLogger().warn("{}:{} already exist", resource, resourceId);
                 if (resource.equals("policy") && commonspec.getResponse().getStatusCode() == 200) {
-                    if (doesNotExist != null) {
+                    if (doesNotExist == true) {
                         //Policy already exists
                         commonspec.getLogger().warn("Policy {} already exist - not created", resourceId);
 

--- a/src/main/java/com/stratio/qa/specs/RestSpec.java
+++ b/src/main/java/com/stratio/qa/specs/RestSpec.java
@@ -26,7 +26,7 @@ import io.cucumber.datatable.DataTable;
 import org.json.JSONArray;
 
 import java.io.*;
-import java.util.*;
+import java.util.Optional;
 import java.util.concurrent.Future;
 import java.util.regex.Pattern;
 
@@ -222,6 +222,19 @@ public class RestSpec extends BaseGSpec {
     }
 
 
+    @When("^I create '(policy|user|group)' '(.+?)' using API service path '(.+?)'( with user and password '(.+:.+?)')? based on '([^:]+?)'( as '(json|string|gov)')? with:$")
+    public void createResource(String resource, String resourceId, String endPoint, String loginInfo, String baseData, String type, DataTable modifications) throws Exception {
+        createResourceIfNotExist(resource, resourceId, endPoint, loginInfo, null, baseData, type, modifications);
+
+    }
+
+
+    @When("^I create '(policy|user|group)' '(.+?)' using API service path '(.+?)'( with user and password '(.+:.+?)')? if it does not exist based on '([^:]+?)'( as '(json|string|gov)')? with:$")
+    public void createResourceIfNotExist(String resource, String resourceId, String endPoint, String loginInfo, String baseData, String type, DataTable modifications) throws Exception {
+        createResourceIfNotExist(resource, resourceId, endPoint, loginInfo, "true", baseData, type, modifications);
+    }
+
+
     /**
      * Creates a custom resource in gosec management if the resource doesn't exist
      *
@@ -235,8 +248,7 @@ public class RestSpec extends BaseGSpec {
      * @param modifications
      * @throws Exception
      */
-    @When("^I create '(.+?)' '(.+?)' in endpoint '(.+?)'( with user and password '(.+:.+?)')?( if it does not exist)? based on '([^:]+?)'( as '(json|string|gov)')? with:$")
-    public void createResourceIfNotExist(String resource, String resourceId, String endPoint, String loginInfo, String doesNotExist, String baseData, String type, DataTable modifications) throws Exception {
+    private void createResourceIfNotExist(String resource, String resourceId, String endPoint, String loginInfo, String doesNotExist, String baseData, String type, DataTable modifications) throws Exception {
         Integer expectedStatusCreate = new Integer(201);
         Integer expectedStatusDelete = new Integer(200);
         String endPointResource = endPoint + "/" + resourceId;
@@ -260,6 +272,7 @@ public class RestSpec extends BaseGSpec {
                     throw e;
                 }
             } else {
+                commonspec.getLogger().warn("{}:{} already exist", resource, resourceId);
                 if (resource.equals("policy") && commonspec.getResponse().getStatusCode() == 200) {
                     if (doesNotExist != null) {
                         //Policy already exists
@@ -448,7 +461,7 @@ public class RestSpec extends BaseGSpec {
 
     @When("^I login to '(.+?)' based on '([^:]+?)' as '(json|string)' with:$")
     public void loginUser(String endPoint, String baseData, String type, DataTable modifications) throws Exception {
-        sendRequest("POST", endPoint,  null, baseData, type, modifications);
+        sendRequest("POST", endPoint, null, baseData, type, modifications);
     }
 
     @When("^I logout from '(.+?)'$")


### PR DESCRIPTION
- Allows method with/without 'if it does not exist'
- Change name 'endpoint' to 'using API service path'
- Enum values for valid resources: policy, user or group
- Added warning message message when resource is already created