### PR TITLE
[SECTY-1440] BDT refactor for gosec 1.1.1 new paths and ids

### DIFF
--- a/src/main/java/com/stratio/qa/specs/RestSpec.java
+++ b/src/main/java/com/stratio/qa/specs/RestSpec.java
@@ -253,6 +253,8 @@ public class RestSpec extends BaseGSpec {
         Integer expectedStatusCreate = 201;
         Integer expectedStatusDelete = 200;
         String endPointResource = endPoint + resourceId;
+        String endPointPolicy = "/service/gosecmanagement/api/policy";
+        String endPointPolicies = "/service/gosecmanagement/api/policies";
 
         if (endPoint.contains("id")) {
             endPoint = endPoint.replace("?id=", "");
@@ -264,13 +266,26 @@ public class RestSpec extends BaseGSpec {
             assertThat(commonspec.getRestHost().isEmpty() || commonspec.getRestPort().isEmpty());
 
             if (resource.equals("policy")) {
-                sendRequestNoDataTable("GET", endPoint, loginInfo, null, null);
+                sendRequestNoDataTable("GET", endPointPolicy, loginInfo, null, null);
                 if (commonspec.getResponse().getStatusCode() == 200) {
                     commonspec.runLocalCommand("echo '" + commonspec.getResponse().getResponse() + "' | jq '.list[] | select (.name == \"" + resourceId + "\").id' | sed s/\\\"//g");
                     String policyId = commonspec.getCommandResult().trim();
                     if (!policyId.equals("")) {
                         commonspec.getLogger().debug("PolicyId obtained: {}", policyId);
                         endPointResource = endPoint + "/" + policyId;
+                    }
+                } else {
+                    if (commonspec.getResponse().getStatusCode() == 404) {
+                        commonspec.getLogger().warn("Error 404 accesing endpoint {}: checking the new endpoint for Gosec 1.1.1", endPointPolicy);
+                        sendRequestNoDataTable("GET", endPointPolicies, loginInfo, null, null);
+                        if (commonspec.getResponse().getStatusCode() == 200) {
+                            commonspec.runLocalCommand("echo '" + commonspec.getResponse().getResponse() + "' | jq '.list[] | select (.name == \"" + resourceId + "\").id' | sed s/\\\"//g");
+                            String policyId = commonspec.getCommandResult().trim();
+                            if (!policyId.equals("")) {
+                                commonspec.getLogger().debug("PolicyId obtained: {}", policyId);
+                                endPointResource = endPoint + "/?id=" + policyId;
+                            }
+                        }
                     }
                 }
             }
@@ -331,6 +346,8 @@ public class RestSpec extends BaseGSpec {
     public void deleteUserIfExists(String resource, String resourceId, String endPoint, String loginInfo) throws Exception {
         Integer expectedStatusDelete = 200;
         String endPointResource = endPoint + resourceId;
+        String endPointPolicy = "/service/gosecmanagement/api/policy";
+        String endPointPolicies = "/service/gosecmanagement/api/policies";
 
         if (endPoint.contains("id")) {
             endPoint = endPoint.replace("?id=", "");
@@ -342,13 +359,26 @@ public class RestSpec extends BaseGSpec {
             assertThat(commonspec.getRestHost().isEmpty() || commonspec.getRestPort().isEmpty());
 
             if (resource.equals("policy")) {
-                sendRequestNoDataTable("GET", endPoint, loginInfo, null, null);
+                sendRequestNoDataTable("GET", endPointPolicy, loginInfo, null, null);
                 if (commonspec.getResponse().getStatusCode() == 200) {
                     commonspec.runLocalCommand("echo '" + commonspec.getResponse().getResponse() + "' | jq '.list[] | select (.name == \"" + resourceId + "\").id' | sed s/\\\"//g");
                     String policyId = commonspec.getCommandResult().trim();
                     if (!policyId.equals("")) {
                         commonspec.getLogger().debug("PolicyId obtained: {}", policyId);
                         endPointResource = endPoint + "/" + policyId;
+                    }
+                } else {
+                    if (commonspec.getResponse().getStatusCode() == 404) {
+                        commonspec.getLogger().warn("Error 404 accesing endpoint {}: checking the new endpoint for Gosec 1.1.1", endPointPolicy);
+                        sendRequestNoDataTable("GET", endPointPolicies, loginInfo, null, null);
+                        if (commonspec.getResponse().getStatusCode() == 200) {
+                            commonspec.runLocalCommand("echo '" + commonspec.getResponse().getResponse() + "' | jq '.list[] | select (.name == \"" + resourceId + "\").id' | sed s/\\\"//g");
+                            String policyId = commonspec.getCommandResult().trim();
+                            if (!policyId.equals("")) {
+                                commonspec.getLogger().debug("PolicyId obtained: {}", policyId);
+                                endPointResource = endPoint + "/?id=" + policyId;
+                            }
+                        }
                     }
                 }
             }

--- a/src/main/java/com/stratio/qa/specs/RestSpec.java
+++ b/src/main/java/com/stratio/qa/specs/RestSpec.java
@@ -255,11 +255,12 @@ public class RestSpec extends BaseGSpec {
         String endPointResource = endPoint + resourceId;
         String endPointPolicy = "/service/gosecmanagement/api/policy";
         String endPointPolicies = "/service/gosecmanagement/api/policies";
+        String newEndPoint = "";
 
         if (endPoint.contains("id")) {
-            endPoint = endPoint.replace("?id=", "");
+            newEndPoint = endPoint.replace("?id=", "");
         } else {
-            endPoint = endPoint.substring(0, endPoint.length() - 1);
+            newEndPoint = endPoint.substring(0, endPoint.length() - 1);
         }
 
         try {
@@ -272,7 +273,7 @@ public class RestSpec extends BaseGSpec {
                     String policyId = commonspec.getCommandResult().trim();
                     if (!policyId.equals("")) {
                         commonspec.getLogger().debug("PolicyId obtained: {}", policyId);
-                        endPointResource = endPoint + "/" + policyId;
+                        endPointResource = newEndPoint + "/" + policyId;
                     }
                 } else {
                     if (commonspec.getResponse().getStatusCode() == 404) {
@@ -283,7 +284,7 @@ public class RestSpec extends BaseGSpec {
                             String policyId = commonspec.getCommandResult().trim();
                             if (!policyId.equals("")) {
                                 commonspec.getLogger().debug("PolicyId obtained: {}", policyId);
-                                endPointResource = endPoint + "/?id=" + policyId;
+                                endPointResource = newEndPoint + "?id=" + policyId;
                             }
                         }
                     }
@@ -293,7 +294,7 @@ public class RestSpec extends BaseGSpec {
             sendRequestNoDataTable("GET", endPointResource, loginInfo, null, null);
 
             if (commonspec.getResponse().getStatusCode() != 200) {
-                sendRequest("POST", endPoint, loginInfo, baseData, type, modifications);
+                sendRequest("POST", newEndPoint, loginInfo, baseData, type, modifications);
                 try {
                     if (commonspec.getResponse().getStatusCode() == 409) {
                         commonspec.getLogger().warn("The resource {} already exists", resourceId);
@@ -376,7 +377,7 @@ public class RestSpec extends BaseGSpec {
                             String policyId = commonspec.getCommandResult().trim();
                             if (!policyId.equals("")) {
                                 commonspec.getLogger().debug("PolicyId obtained: {}", policyId);
-                                endPointResource = endPoint + "/?id=" + policyId;
+                                endPointResource = endPoint + "?id=" + policyId;
                             }
                         }
                     }

--- a/src/main/java/com/stratio/qa/specs/RestSpec.java
+++ b/src/main/java/com/stratio/qa/specs/RestSpec.java
@@ -256,6 +256,8 @@ public class RestSpec extends BaseGSpec {
 
         if (endPoint.contains("id")) {
             endPoint = endPoint.replace("?id=", "");
+        } else {
+            endPoint = endPoint.substring(0, endPoint.length() - 1);
         }
 
         try {
@@ -332,6 +334,8 @@ public class RestSpec extends BaseGSpec {
 
         if (endPoint.contains("id")) {
             endPoint = endPoint.replace("?id=", "");
+        } else {
+            endPoint = endPoint.substring(0, endPoint.length() - 1);
         }
 
         try {


### PR DESCRIPTION
- Make create and delete resources methods compatible with new endpoints in gosec 1.1.1
- Added new endpoint searching policy by ID if the response is 404