### PR TITLE
[GS-1538] Allow response 204 deleting gosec resources

### DIFF
--- a/src/main/java/com/stratio/qa/specs/RestSpec.java
+++ b/src/main/java/com/stratio/qa/specs/RestSpec.java
@@ -350,7 +350,7 @@ public class RestSpec extends BaseGSpec {
      */
     @When("^I delete '(policy|user|group)' '(.+?)' using API service path '(.+?)'( with user and password '(.+:.+?)')? if it exists$")
     public void deleteUserIfExists(String resource, String resourceId, String endPoint, String loginInfo) throws Exception {
-        Integer expectedStatusDelete = 200;
+        Integer[] expectedStatusDelete = {200, 204};
         String endPointResource = endPoint + resourceId;
         String endPointPolicy = "/service/gosecmanagement/api/policy";
         String endPointPolicies = "/service/gosecmanagement/api/policies";
@@ -397,7 +397,7 @@ public class RestSpec extends BaseGSpec {
                 commonspec.getLogger().debug("Resource {} deleted", resourceId);
 
                 try {
-                    assertThat(commonspec.getResponse().getStatusCode()).isEqualTo(expectedStatusDelete);
+                    assertThat(commonspec.getResponse().getStatusCode()).isIn(expectedStatusDelete);
                 } catch (Exception e) {
                     commonspec.getLogger().warn("Error deleting Resource {}: {}", resourceId, commonspec.getResponse().getResponse());
                     throw e;

--- a/src/test/resources/features/readWebElementTextToVariable.feature
+++ b/src/test/resources/features/readWebElementTextToVariable.feature
@@ -4,6 +4,6 @@ Feature: Get webElement text and store in environment variable
   Scenario: Use google
     Given My app is running in 'www.google.es'
     When I browse to '/'
-    Then '2' element exists with 'css:a[class="gb_e"]'
+    Then '2' element exists with 'css:a[class="gb_g"]'
     When I save content of element in index '0' in environment variable 'textCorreo'
     Then I run 'echo '!{textCorreo}' | grep "Gmail"' locally with exit status '0'


### PR DESCRIPTION
- From version 1.3.0, management API for creation/deletion of users, calls identties-daas and its http response code when a user is deleted is defined as '204' instead '200' therefore this is a change to make it compatible