### PR TITLE
[SPK-914] Complete new getHostIP method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Only listing significant user-visible, not internal code cleanups and minor bug 
 
 * Bump log4j-core, log4j-slf4j-impl and log4j-1.2-api from 2.0 to 2.13.2
 * [GS-2354] Add feature to convert provided date into timestamp
+* [SPK-914] Complete new getHostIP method
 
 ## 0.18.0 (August 04, 2020)
 

--- a/src/main/java/com/stratio/qa/specs/CCTSpec.java
+++ b/src/main/java/com/stratio/qa/specs/CCTSpec.java
@@ -98,9 +98,15 @@ public class CCTSpec extends BaseGSpec {
     public void getHostIp(String internalIP, String taskName, String serviceId, String envVar) throws Exception {
         if (ThreadProperty.get("cct-marathon-services_id") == null) {
             DeployedTask task = getServiceTaskFromDeployApi(serviceId, taskName);
+            if (task == null) {
+                fail("Error obtaining IP");
+            }
             ThreadProperty.set(envVar, internalIP != null ? task.getCalicoIP() : task.getHost());
         } else {
             DeployedServiceTask task = getServiceTaskFromCctMarathonService(serviceId, taskName);
+            if (task == null) {
+                fail("Error obtaining IP");
+            }
             ThreadProperty.set(envVar, internalIP != null ? task.getSecuredHost() : task.getHost());
         }
     }

--- a/src/main/java/com/stratio/qa/specs/CCTSpec.java
+++ b/src/main/java/com/stratio/qa/specs/CCTSpec.java
@@ -94,15 +94,19 @@ public class CCTSpec extends BaseGSpec {
         }
     }
 
-    @When("^I get host ip for task '(.+?)' in service with id '(.+?)' from CCT and save the value in environment variable '(.+?)'$")
-    public void getHostIp(String taskName, String serviceId, String envVar) throws Exception {
+    @When("^I get (internal )?host ip for task '(.+?)' in service with id '(.+?)' from CCT and save the value in environment variable '(.+?)'$")
+    public void getHostIp(String internalIP, String taskName, String serviceId, String envVar) throws Exception {
         if (ThreadProperty.get("cct-marathon-services_id") == null) {
             DeployedTask task = getServiceTaskFromDeployApi(serviceId, taskName);
-            ThreadProperty.set(envVar, task.getHost());
+            ThreadProperty.set(envVar, internalIP != null ? task.getCalicoIP() : task.getHost());
         } else {
             DeployedServiceTask task = getServiceTaskFromCctMarathonService(serviceId, taskName);
-            ThreadProperty.set(envVar, task.getHost());
+            ThreadProperty.set(envVar, internalIP != null ? task.getSecuredHost() : task.getHost());
         }
+    }
+
+    public void getHostIp(String taskName, String serviceId, String envVar) throws Exception {
+        getHostIp(null, taskName, serviceId, envVar);
     }
 
     private DeployedTask getServiceTaskFromDeployApi(String serviceId, String taskName) throws Exception {


### PR DESCRIPTION
Se creó el método getHostIP, deprecando el antiguo método getMachineIp, pero no permitiamos obtener la IP interna.

Se ha añadido un argumento al método getHostIP para poder obtener tanto IP interna como externa de un servicio