### PR TITLE
[ROCK-2116] Handle Discovery Token

### DIFF
--- a/src/main/java/com/stratio/qa/specs/CommonG.java
+++ b/src/main/java/com/stratio/qa/specs/CommonG.java
@@ -2518,7 +2518,7 @@ public class CommonG {
 
         // Set sso token
         DcosSpec dcosSpec = new DcosSpec(this);
-        dcosSpec.setGoSecSSOCookie(null, null, ThreadProperty.get("EOS_ACCESS_POINT"), user, password, tenant, null, null);
+        dcosSpec.setGoSecSSOCookie(null, null, ThreadProperty.get("EOS_ACCESS_POINT"), user, password, tenant, null);
 
         // Securely send requests
         this.setRestProtocol("https://");

--- a/src/main/java/com/stratio/qa/specs/CommonG.java
+++ b/src/main/java/com/stratio/qa/specs/CommonG.java
@@ -2518,7 +2518,7 @@ public class CommonG {
 
         // Set sso token
         DcosSpec dcosSpec = new DcosSpec(this);
-        dcosSpec.setGoSecSSOCookie(null, null, ThreadProperty.get("EOS_ACCESS_POINT"), user, password, tenant, null);
+        dcosSpec.setGoSecSSOCookie(null, null, ThreadProperty.get("EOS_ACCESS_POINT"), user, password, tenant, null, null);
 
         // Securely send requests
         this.setRestProtocol("https://");

--- a/src/main/java/com/stratio/qa/specs/DcosSpec.java
+++ b/src/main/java/com/stratio/qa/specs/DcosSpec.java
@@ -146,7 +146,7 @@ public class DcosSpec extends BaseGSpec {
             if (gov != null) {
                 tokenList = new String[]{"user", "dcos-acs-auth-cookie", "stratio-governance-auth"};
             }
-            if (discoveryCookie != null) {
+            if ((discoveryCookie != null) && (gov == null)) {
                 tokenList = new String[]{discoveryCookie};
             }
             List<com.ning.http.client.cookie.Cookie> cookiesAtributes = addSsoToken(ssoCookies, tokenList);


### PR DESCRIPTION
Upgrate Discovery Token method with last versions.

Examples of use:
    

- Given I set sso token using host '!{DISCOVERY_HOST}/${DISCOVERY_ID:-discovery-qa}/auth' with user '${DCOS_TENANT1_OWNER_USER}' and password '${DCOS_TENANT1_OWNER_PASSWORD}' and tenant '${DCOS_TENANT1}' without host name verification with discovery cookie '${DCOS_TENANT1}-${DISCOVERY_ID:-discovery-qa}-auth-cookie'

- Given I obtain metabase id for user '${USER}' and password '${PASSWORD}' in endpoint 'https://!{DISCOVERY_HOST}/${DISCOVERY_ID:-discovery-qa}${DISCOVERY_SESSION:-/api/session}' and save in context cookies
