### PR TITLE
[QATM-3626] Get _oauth2_proxy and stratio-cookie in KEOS

### DIFF
--- a/src/main/java/com/stratio/qa/specs/CommonG.java
+++ b/src/main/java/com/stratio/qa/specs/CommonG.java
@@ -2637,4 +2637,21 @@ public class CommonG {
     public void initKubernetesClient() {
         kubernetesClient = KubernetesClient.getInstance();
     }
+
+    /**
+     * Obtain cookies from previous request
+     *
+     * @param ssoCookies
+     * @param tokenList
+     * @return
+     */
+    public List<com.ning.http.client.cookie.Cookie> addSsoToken(HashMap<String, String> ssoCookies, String[] tokenList) {
+        List<com.ning.http.client.cookie.Cookie> cookiesAttributes = new ArrayList<>();
+        for (String tokenKey : tokenList) {
+            cookiesAttributes.add(new com.ning.http.client.cookie.Cookie(tokenKey, ssoCookies.get(tokenKey),
+                    false, null,
+                    null, 999999, false, false));
+        }
+        return cookiesAttributes;
+    }
 }

--- a/src/main/java/com/stratio/qa/specs/DcosSpec.java
+++ b/src/main/java/com/stratio/qa/specs/DcosSpec.java
@@ -150,7 +150,7 @@ public class DcosSpec extends BaseGSpec {
             if (gov != null) {
                 tokenList = new String[]{"user", "dcos-acs-auth-cookie", "stratio-governance-auth"};
             }
-            List<com.ning.http.client.cookie.Cookie> cookiesAtributes = addSsoToken(ssoCookies, tokenList);
+            List<com.ning.http.client.cookie.Cookie> cookiesAtributes = this.commonspec.addSsoToken(ssoCookies, tokenList);
 
             this.commonspec.getLogger().debug("Cookies to set:");
             for (String cookie:tokenList) {
@@ -186,30 +186,13 @@ public class DcosSpec extends BaseGSpec {
         ssoUtils.setVerifyHost(hostVerifier == null);
         HashMap<String, String> ssoCookies = ssoUtils.ssoTokenGenerator();
         String[] tokenList = new String[]{discoveryCookie};
-        List<com.ning.http.client.cookie.Cookie> cookiesAtributes = addSsoToken(ssoCookies, tokenList);
+        List<com.ning.http.client.cookie.Cookie> cookiesAtributes = this.commonspec.addSsoToken(ssoCookies, tokenList);
         this.commonspec.getLogger().debug("Discovery Cookie to set:");
         for (String cookie : tokenList) {
             this.commonspec.getLogger().debug("\t" + cookie + ":" + ssoCookies.get(cookie));
         }
         ThreadProperty.set(discoveryCookie, ssoCookies.get(discoveryCookie));
         commonspec.setCookies(cookiesAtributes);
-    }
-
-    /**
-     * Obtain cookies from previous request
-     * @param ssoCookies
-     * @param tokenList
-     * @return
-     */
-    public List<com.ning.http.client.cookie.Cookie> addSsoToken(HashMap<String, String> ssoCookies, String[] tokenList) {
-        List<com.ning.http.client.cookie.Cookie> cookiesAttributes = new ArrayList<>();
-
-        for (String tokenKey : tokenList) {
-            cookiesAttributes.add(new com.ning.http.client.cookie.Cookie(tokenKey, ssoCookies.get(tokenKey),
-                    false, null,
-                    null, 999999, false, false));
-        }
-        return cookiesAttributes;
     }
 
     /**

--- a/src/main/java/com/stratio/qa/specs/HookGSpec.java
+++ b/src/main/java/com/stratio/qa/specs/HookGSpec.java
@@ -285,7 +285,7 @@ public class HookGSpec extends BaseGSpec {
         }
     }
 
-    @Before(order = ORDER_10, value = "@rest or @dcos")
+    @Before(order = ORDER_10, value = "@rest or @dcos or @keos")
     public void restClientSetup() throws Exception {
         commonspec.getLogger().debug("Starting a REST client");
 
@@ -299,7 +299,7 @@ public class HookGSpec extends BaseGSpec {
         commonspec.initKubernetesClient();
     }
 
-    @After(order = ORDER_10, value = "@rest or @dcos")
+    @After(order = ORDER_10, value = "@rest or @dcos or @keos")
     public void restClientTeardown() throws IOException {
         commonspec.getLogger().debug("Shutting down REST client");
         commonspec.getClient().close();

--- a/src/main/java/com/stratio/qa/specs/K8SSpec.java
+++ b/src/main/java/com/stratio/qa/specs/K8SSpec.java
@@ -19,6 +19,7 @@ package com.stratio.qa.specs;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import com.stratio.qa.utils.GosecSSOUtils;
 import com.stratio.qa.utils.ThreadProperty;
 import cucumber.api.java.en.Given;
 import cucumber.api.java.en.Then;
@@ -32,6 +33,7 @@ import org.testng.Assert;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -69,32 +71,45 @@ public class K8SSpec extends BaseGSpec {
     public void getList(String type, String namespace, String envVar) {
         String response = null;
         switch (type) {
-            case "pods":    response = commonspec.kubernetesClient.getNamespacePods(namespace);
-                            break;
-            case "configmaps":  response = commonspec.kubernetesClient.getConfigMapList(namespace);
-                                break;
-            case "serviceaccounts": response = commonspec.kubernetesClient.getServiceAccountList(namespace);
-                                    break;
-            case "replicasets":     response = commonspec.kubernetesClient.getReplicaSetList(namespace);
-                                    break;
-            case "secrets":     response = commonspec.kubernetesClient.getSecretsList(namespace);
-                                break;
-            case "clusterroles":    response = commonspec.kubernetesClient.getClusterRoleList(namespace);
-                                    break;
-            case "clusterrolebindings":     response = commonspec.kubernetesClient.getClusterRoleBindingList(namespace);
-                                            break;
-            case "statefulsets":    response = commonspec.kubernetesClient.getStateFulSetList(namespace);
-                                    break;
-            case "roles":   response = commonspec.kubernetesClient.getRoleList(namespace);
-                            break;
-            case "rolebindings":    response = commonspec.kubernetesClient.getRoleBindingList(namespace);
-                                    break;
-            case "customresourcedefinitions":    response = commonspec.kubernetesClient.getCustomResourceDefinitionList();
-                                                break;
-            case "deployments":    response = commonspec.kubernetesClient.getDeploymentList(namespace);
-                                  break;
-            case "services":    response = commonspec.kubernetesClient.getServiceList(namespace);
-                              break;
+            case "pods":
+                response = commonspec.kubernetesClient.getNamespacePods(namespace);
+                break;
+            case "configmaps":
+                response = commonspec.kubernetesClient.getConfigMapList(namespace);
+                break;
+            case "serviceaccounts":
+                response = commonspec.kubernetesClient.getServiceAccountList(namespace);
+                break;
+            case "replicasets":
+                response = commonspec.kubernetesClient.getReplicaSetList(namespace);
+                break;
+            case "secrets":
+                response = commonspec.kubernetesClient.getSecretsList(namespace);
+                break;
+            case "clusterroles":
+                response = commonspec.kubernetesClient.getClusterRoleList(namespace);
+                break;
+            case "clusterrolebindings":
+                response = commonspec.kubernetesClient.getClusterRoleBindingList(namespace);
+                break;
+            case "statefulsets":
+                response = commonspec.kubernetesClient.getStateFulSetList(namespace);
+                break;
+            case "roles":
+                response = commonspec.kubernetesClient.getRoleList(namespace);
+                break;
+            case "rolebindings":
+                response = commonspec.kubernetesClient.getRoleBindingList(namespace);
+                break;
+            case "customresourcedefinitions":
+                response = commonspec.kubernetesClient.getCustomResourceDefinitionList();
+                break;
+            case "deployments":
+                response = commonspec.kubernetesClient.getDeploymentList(namespace);
+                break;
+            case "services":
+                response = commonspec.kubernetesClient.getServiceList(namespace);
+                break;
             default:
         }
         ThreadProperty.set(envVar, response);
@@ -115,31 +130,44 @@ public class K8SSpec extends BaseGSpec {
         String describeResponse;
         format = (format != null) ? format : "yaml";
         switch (type) {
-            case "pod": describeResponse = commonspec.kubernetesClient.describePodYaml(name, namespace);
-                        break;
-            case "service": describeResponse = commonspec.kubernetesClient.describeServiceYaml(name, namespace);
-                            break;
-            case "deployment": describeResponse = commonspec.kubernetesClient.describeDeploymentYaml(name, namespace);
-                            break;
-            case "configmap":   describeResponse = commonspec.kubernetesClient.describeConfigMap(name, namespace);
-                                break;
-            case "replicaset":  describeResponse = commonspec.kubernetesClient.describeReplicaSet(name, namespace);
-                                break;
-            case "serviceaccount":  describeResponse = commonspec.kubernetesClient.describeServiceAccount(name, namespace);
-                                    break;
-            case "secret":  describeResponse = commonspec.kubernetesClient.describeSecret(name, namespace);
-                            break;
-            case "clusterrole":     describeResponse = commonspec.kubernetesClient.describeClusterRole(name, namespace);
-                                    break;
-            case "clusterrolebinding":  describeResponse = commonspec.kubernetesClient.describeClusterRoleBinding(name, namespace);
-                                        break;
-            case "statefulset":     describeResponse = commonspec.kubernetesClient.describeStateFulSet(name, namespace);
-                                    break;
-            case "role":    describeResponse = commonspec.kubernetesClient.describeRole(name, namespace);
-                            break;
-            case "rolebinding":     describeResponse = commonspec.kubernetesClient.describeRoleBinding(name, namespace);
-                                    break;
-            default:    describeResponse = null;
+            case "pod":
+                describeResponse = commonspec.kubernetesClient.describePodYaml(name, namespace);
+                break;
+            case "service":
+                describeResponse = commonspec.kubernetesClient.describeServiceYaml(name, namespace);
+                break;
+            case "deployment":
+                describeResponse = commonspec.kubernetesClient.describeDeploymentYaml(name, namespace);
+                break;
+            case "configmap":
+                describeResponse = commonspec.kubernetesClient.describeConfigMap(name, namespace);
+                break;
+            case "replicaset":
+                describeResponse = commonspec.kubernetesClient.describeReplicaSet(name, namespace);
+                break;
+            case "serviceaccount":
+                describeResponse = commonspec.kubernetesClient.describeServiceAccount(name, namespace);
+                break;
+            case "secret":
+                describeResponse = commonspec.kubernetesClient.describeSecret(name, namespace);
+                break;
+            case "clusterrole":
+                describeResponse = commonspec.kubernetesClient.describeClusterRole(name, namespace);
+                break;
+            case "clusterrolebinding":
+                describeResponse = commonspec.kubernetesClient.describeClusterRoleBinding(name, namespace);
+                break;
+            case "statefulset":
+                describeResponse = commonspec.kubernetesClient.describeStateFulSet(name, namespace);
+                break;
+            case "role":
+                describeResponse = commonspec.kubernetesClient.describeRole(name, namespace);
+                break;
+            case "rolebinding":
+                describeResponse = commonspec.kubernetesClient.describeRoleBinding(name, namespace);
+                break;
+            default:
+                describeResponse = null;
         }
         if (describeResponse == null) {
             fail("Error obtaining " + type + " information");
@@ -387,12 +415,15 @@ public class K8SSpec extends BaseGSpec {
     @When("^I delete (pod|deployment|service) with name '(.+?)' in namespace '(.+?)'$")
     public void deleteResource(String type, String name, String namespace) {
         switch (type) {
-            case "pod":     commonspec.kubernetesClient.deletePod(name, namespace);
-                            break;
-            case "deployment":  commonspec.kubernetesClient.deleteDeployment(name, namespace);
-                                break;
-            case "service":     commonspec.kubernetesClient.deleteService(name, namespace);
-                                break;
+            case "pod":
+                commonspec.kubernetesClient.deletePod(name, namespace);
+                break;
+            case "deployment":
+                commonspec.kubernetesClient.deleteDeployment(name, namespace);
+                break;
+            case "service":
+                commonspec.kubernetesClient.deleteService(name, namespace);
+                break;
             default:
         }
     }
@@ -411,24 +442,33 @@ public class K8SSpec extends BaseGSpec {
     @When("^I get (pods|deployments|replicasets|services|statefulsets|configmaps|serviceacounts|roles|rolebindings) using the following label filter '(.+?)'( in namespace '(.+?)')? and save it in environment variable '(.+?)'$")
     public void getPodsLabelSelector(String type, String selector, String namespace, String envVar) {
         switch (type) {
-            case "pods":    ThreadProperty.set(envVar, commonspec.kubernetesClient.getPodsFilteredByLabel(selector, namespace));
-                            break;
-            case "deployments":     ThreadProperty.set(envVar, commonspec.kubernetesClient.getDeploymentsFilteredByLabel(selector, namespace));
-                                    break;
-            case "replicasets":     ThreadProperty.set(envVar, commonspec.kubernetesClient.getReplicaSetsFilteredByLabel(selector, namespace));
-                                    break;
-            case "services":     ThreadProperty.set(envVar, commonspec.kubernetesClient.getServicesFilteredByLabel(selector, namespace));
-                                    break;
-            case "statefulsets":     ThreadProperty.set(envVar, commonspec.kubernetesClient.getStateFulSetsFilteredByLabel(selector, namespace));
-                                    break;
-            case "configmaps":     ThreadProperty.set(envVar, commonspec.kubernetesClient.getConfigMapsFilteredByLabel(selector, namespace));
-                                    break;
-            case "serviceaccounts":     ThreadProperty.set(envVar, commonspec.kubernetesClient.getServiceAccountsFilteredByLabel(selector, namespace));
-                                        break;
-            case "roles":     ThreadProperty.set(envVar, commonspec.kubernetesClient.getRolesFilteredByLabel(selector, namespace));
-                              break;
-            case "rolebindings":     ThreadProperty.set(envVar, commonspec.kubernetesClient.getRolesBindingsFilteredByLabel(selector, namespace));
-                              break;
+            case "pods":
+                ThreadProperty.set(envVar, commonspec.kubernetesClient.getPodsFilteredByLabel(selector, namespace));
+                break;
+            case "deployments":
+                ThreadProperty.set(envVar, commonspec.kubernetesClient.getDeploymentsFilteredByLabel(selector, namespace));
+                break;
+            case "replicasets":
+                ThreadProperty.set(envVar, commonspec.kubernetesClient.getReplicaSetsFilteredByLabel(selector, namespace));
+                break;
+            case "services":
+                ThreadProperty.set(envVar, commonspec.kubernetesClient.getServicesFilteredByLabel(selector, namespace));
+                break;
+            case "statefulsets":
+                ThreadProperty.set(envVar, commonspec.kubernetesClient.getStateFulSetsFilteredByLabel(selector, namespace));
+                break;
+            case "configmaps":
+                ThreadProperty.set(envVar, commonspec.kubernetesClient.getConfigMapsFilteredByLabel(selector, namespace));
+                break;
+            case "serviceaccounts":
+                ThreadProperty.set(envVar, commonspec.kubernetesClient.getServiceAccountsFilteredByLabel(selector, namespace));
+                break;
+            case "roles":
+                ThreadProperty.set(envVar, commonspec.kubernetesClient.getRolesFilteredByLabel(selector, namespace));
+                break;
+            case "rolebindings":
+                ThreadProperty.set(envVar, commonspec.kubernetesClient.getRolesBindingsFilteredByLabel(selector, namespace));
+                break;
             default:
         }
     }
@@ -441,10 +481,12 @@ public class K8SSpec extends BaseGSpec {
     @Given("^I forward containerPort '(\\d+)' in localhostPort '(\\d+)' for (pod|service) '(.+?)'( in namespace '(.+?)')?$")
     public void setLocalPortForward(Integer containerPort, Integer localhostPort, String type, String name, String namespace) {
         switch (type) {
-            case "pod":     commonspec.kubernetesClient.setLocalPortForwardPod(namespace, name, containerPort, localhostPort);
-                            break;
-            case "service": commonspec.kubernetesClient.setLocalPortForwardService(namespace, name, containerPort, localhostPort);
-                            break;
+            case "pod":
+                commonspec.kubernetesClient.setLocalPortForwardPod(namespace, name, containerPort, localhostPort);
+                break;
+            case "service":
+                commonspec.kubernetesClient.setLocalPortForwardService(namespace, name, containerPort, localhostPort);
+                break;
             default:
         }
     }
@@ -452,5 +494,38 @@ public class K8SSpec extends BaseGSpec {
     @Then("^I close port forward$")
     public void closePortForward() throws IOException {
         commonspec.kubernetesClient.closePortForward();
+    }
+
+    /**
+     * Generate token to authenticate in gosec SSO in Keos
+     *
+     * @param ssoHost  : current sso host
+     * @param userName : username
+     * @param password : password
+     * @param tenant   : tenant
+     * @throws Exception exception
+     */
+    @Given("^I set sso keos token using host '(.+?)' with user '(.+?)', password '(.+?)' and tenant '(.+?)'$")
+    public void setGoSecSSOCookieKeos(String ssoHost, String userName, String password, String tenant) throws Exception {
+        GosecSSOUtils ssoUtils = new GosecSSOUtils(ssoHost + "/service/cct-ui/", userName, password, tenant, null);
+        ssoUtils.setVerifyHost(false);
+        HashMap<String, String> ssoCookies = ssoUtils.ssoTokenGenerator(false);
+        String[] tokenList = {"_oauth2_proxy"};
+        List<com.ning.http.client.cookie.Cookie> cookiesAtributes = commonspec.addSsoToken(ssoCookies, tokenList);
+        commonspec.setCookies(cookiesAtributes);
+        RestSpec restSpec = new RestSpec(commonspec);
+        restSpec.setupRestClient("securely", ssoHost, ":443");
+        restSpec.sendRequestNoDataTable("GET", "/service/cct-ui/", null, null, null);
+        for (com.ning.http.client.cookie.Cookie cookie : commonspec.getResponse().getCookies()) {
+            if (cookie.getName().equals("stratio-cookie")) {
+                cookiesAtributes.add(cookie);
+                break;
+            }
+        }
+        this.commonspec.getLogger().debug("Cookies to set:");
+        for (String cookie : tokenList) {
+            this.commonspec.getLogger().debug("\t" + cookie + ":" + ssoCookies.get(cookie));
+        }
+        commonspec.setCookies(cookiesAtributes);
     }
 }

--- a/src/main/java/com/stratio/qa/utils/GosecSSOUtils.java
+++ b/src/main/java/com/stratio/qa/utils/GosecSSOUtils.java
@@ -73,13 +73,20 @@ public class GosecSSOUtils {
         this.governance = gov;
     }
 
+    /**
+     * Compatibility
+     */
+    @Deprecated
+    public HashMap<String, String> ssoTokenGenerator() throws Exception {
+        return ssoTokenGenerator(true);
+    }
 
     /**
-     * This method provide dcos and sso token to be used to generate client cookie
+     * This method provide tokens to be used to generate client cookie
      * @return cookieToken list of token generated
      * @throws Exception exception
      */
-    public HashMap<String, String> ssoTokenGenerator() throws Exception {
+    public HashMap<String, String> ssoTokenGenerator(boolean addLogin) throws Exception {
         String protocol = "https://";
         HashMap<String, String> cookieToken = new HashMap<>();
 
@@ -88,6 +95,9 @@ public class GosecSSOUtils {
         sslContext.init(null, ALL_TRUSTING_TRUST_MANAGER, new SecureRandom());
         HttpClientContext context = HttpClientContext.create();
         HttpGet httpGet = new HttpGet(protocol + ssoHost + "/login");
+        if (!addLogin) {
+            httpGet = new HttpGet(protocol + ssoHost);
+        }
         HttpClientBuilder clientBuilder = HttpClientBuilder.create()
                 .setSslcontext(sslContext)
                 .setRedirectStrategy(new LaxRedirectStrategy())


### PR DESCRIPTION
Se añade nuevo step para obtener cookies que utilizaremos en servicios desplegados en KEOS.
Probado con CCT y Gosec y parece que funciona OK

Nota: Es una primera aproximación, si finalmente hubiese front en KEOS o similar habría que dar una vuelta

Ejemplo:

  @keos
  Scenario: test
    And I set sso keos token using host 'admin.golf.int' with user 'admin', password '1234' and tenant 'NONE'
    When I securely send requests to 'admin.golf.int:443'
    When I send a 'GET' request to '/service/cct-applications-query-service/v1/applications'
    Then the service response status must be '200'
    When I send a 'GET' request to '/baas/management/users'
    Then the service response status must be '200'